### PR TITLE
Update to reflect correct dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
     "require": {
         "php": ">=7.2",
         "doctrine/dbal": "^2.10",
-        "illuminate/support": "^5.4|^6.0|^7.0",
-        "illuminate/contracts": "^5.4|^6.0|^7.0",
-        "illuminate/database": "^5.4|^6.0|^7.0",
-        "illuminate/queue": "^5.4|^6.0|^7.0",
-        "illuminate/events": "^5.4|^6.0|^7.0"
+        "illuminate/support": "^5.8|^6.0|^7.0",
+        "illuminate/contracts": "^5.8|^6.0|^7.0",
+        "illuminate/database": "^5.8|^6.0|^7.0",
+        "illuminate/queue": "^5.8|^6.0|^7.0",
+        "illuminate/events": "^5.8|^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",


### PR DESCRIPTION
The `MigrationsEnded` event was brought in in Laravel `5.8`. Accordingly previous versions cannot be supported