### PR TITLE
Bug fix

### DIFF
--- a/src/UpdateAttribute.php
+++ b/src/UpdateAttribute.php
@@ -23,6 +23,7 @@ trait UpdateAttribute
 
     protected function updateSqliteAutoIncrement($table): void
     {
-        DB::statement("INSERT OR REPLACE INTO SQLITE_SEQUENCE('name', 'seq') VALUES('{$table}', {$this->autoIncrement})");
+        DB::statement("DELETE FROM SQLITE_SEQUENCE WHERE name = '{$table}'");
+        DB::statement("INSERT INTO SQLITE_SEQUENCE(name, seq) VALUES('{$table}', {$this->autoIncrement})");
     }
 }


### PR DESCRIPTION
If a value already exists in the `sqlite` database table `SQLITE_SEQUENCE`, due to no primary key being present another entry gets added.

Also, addition of this entry does not help as the system uses the first entry (older).